### PR TITLE
Support non-global author configuration

### DIFF
--- a/features/adding_an_author.feature
+++ b/features/adding_an_author.feature
@@ -25,3 +25,9 @@ Feature: Adding an author
     And  I add the author "Bob Dole"
     And  I add the author "Jimmy <asdf"
     Then the config file should have no authors
+
+  Scenario: manually adding an author to the local git configuration
+    Given my local Git configuration contains the author "Linus Torvalds <linus@example.org>"
+    Then `git pair` should display "Linus Torvalds" in its author list
+    And the gitconfig should include "Linus Torvalds" in its author list only once
+    And the gitconfig should include "linus@example.org" as the email of "Linus Torvalds"

--- a/features/step_definitions/config_steps.rb
+++ b/features/step_definitions/config_steps.rb
@@ -2,6 +2,10 @@ Given /^I have added the author "([^\"]*)"$/ do |name_and_email|
   When %(I add the author "#{name_and_email}")
 end
 
+Given /^my local Git configuration contains the author "([^\"]*)"$/ do |name_and_email|
+  git_config "--local --add git-pair.authors \"#{name_and_email}\""
+end
+
 Given /^my global Git configuration is setup with user "([^\"]*)"$/ do |name|
   git_config "--global user.name \"#{name}\""
 end

--- a/lib/git-pair/config.rb
+++ b/lib/git-pair/config.rb
@@ -5,7 +5,7 @@ module GitPair
     DEFAULT_PATTERN = "devs+%abbr+%abbr@%domain"
 
     def all_author_strings
-      `git config --global --get-all git-pair.authors`.split("\n")
+      `git config --get-all git-pair.authors`.split("\n")
     end
 
     def pattern


### PR DESCRIPTION
Hi there,

Firstly, thanks very much for providing this tool - I've been pairing a lot more recently, and it's been really handy.

Frequently I would like to specify git-pair configuration that differs on different laptops or projects. To achieve this I use local or included git configuration as appropriate, editing them manually rather than using git-pair's `--add` flag.

To support this, I've queried the configured authors from all applicable configuration, instead of just the `--global` scope (this now matches the approach taken for fetching the pattern config). I haven't touched the setter options - these still write to the global scope as before.

Hope this is of use - no worries whatsoever if you'd rather not accept modifications to a long-stable gem, though. :smiley: 